### PR TITLE
Support close codes

### DIFF
--- a/luau/webSocket.luau
+++ b/luau/webSocket.luau
@@ -55,11 +55,11 @@ function WebSocket:_request(url, method, body)
 	end
 end
 
-function WebSocket:_close(reason)
+function WebSocket:_close(code, reason)
 	self.connected = false
 
 	for _, callback in self.oncloseCallbacks do
-		task.spawn(callback, reason)
+		task.spawn(callback, code, reason)
 	end
 end
 
@@ -69,7 +69,7 @@ function WebSocket:_incoming(message)
 			task.spawn(callback, message.content)
 		end
 	elseif message.type == "close" then
-		self:_close(message.reason)
+		self:_close(message.code, message.reason)
 	end
 end
 
@@ -83,7 +83,7 @@ function WebSocket:_startPolling()
 			if not success then
 				-- The socket is dead and/or got cleaned up.
 				if response == "Socket not alive" or response == "Socket not found" then
-					self:_close(response)
+					self:_close(1005, response)
 					break
 				end
 
@@ -131,14 +131,14 @@ function WebSocket:send(data)
 	return success
 end
 
-function WebSocket:close()
+function WebSocket:close(code, reason)
 	if not self.connected then
 		warn("Cannot close disconnected websocket")
 		return
 	end
 
 	local closeUrl = string.format(CLOSE_URL, self.socketId)
-	local success, message = self:_request(closeUrl, "DELETE")
+	local success, message = self:_request(closeUrl, "DELETE", { code = code, reason = reason })
 	if not success then
 		warn("Error closing socket:", message)
 	end

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use tokio::sync::{mpsc::Sender, Mutex, Notify};
-use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::{protocol::frame::coding::CloseCode, Message};
 use uuid::Uuid;
 
 #[derive(Clone)]
@@ -25,7 +25,7 @@ impl AppState {
 }
 
 pub enum SocketPacket {
-    Close,
+    Close(Option<CloseCode>, Option<String>),
     Message(String),
 }
 

--- a/src/endpoints/close_socket.rs
+++ b/src/endpoints/close_socket.rs
@@ -1,4 +1,8 @@
-use axum::extract::{Path, State};
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::{
@@ -6,13 +10,25 @@ use crate::{
     authentication::Authentication, AppState,
 };
 
+/// The `#[serde(default)]` isn't normally required, but it must be explicitly provided because of Axum.
+#[derive(Deserialize)]
+pub struct SocketSendBody {
+    #[serde(default)]
+    code: Option<u16>,
+
+    #[serde(default)]
+    reason: Option<String>,
+}
+
 pub async fn close_socket(
     Authentication: Authentication,
     State(state): State<AppState>,
     Path(socket_id): Path<Uuid>,
+    Json(body): Json<SocketSendBody>,
 ) -> Result<ApiResponse<()>, ApiError> {
     if let Some(socket) = state.find_socket(socket_id).await {
-        socket.sender.send(SocketPacket::Close).await?;
+        let packet = SocketPacket::Close(body.code.map(Into::into), body.reason.map(Into::into));
+        socket.sender.send(packet).await?;
 
         return Ok(ApiResponse(()));
     }

--- a/src/endpoints/get_socket.rs
+++ b/src/endpoints/get_socket.rs
@@ -31,7 +31,7 @@ pub struct SocketQuery {
 #[serde(rename_all = "camelCase")]
 pub enum SocketMessage {
     Content { content: String },
-    Close { reason: Option<String> },
+    Close { code: u16, reason: Option<String> },
 }
 
 pub async fn get_socket(
@@ -88,6 +88,7 @@ fn convert_message(message: Message) -> Option<SocketMessage> {
     match message {
         Message::Text(content) => Some(SocketMessage::Content { content }),
         Message::Close(close_frame) => Some(SocketMessage::Close {
+            code: close_frame.as_ref().map_or(1005, |v| v.code.into()),
             reason: close_frame.map(|v| v.reason.into_owned()),
         }),
         _ => None,


### PR DESCRIPTION
`onClosed` will now pass the close code and then the reason. Some applications use close codes to define disconnect behavior.

Additionally, both a close code and reason can be provided via the `:close(code, reason)` method.